### PR TITLE
Fix: clear touch/pinch state when disabling

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,11 @@ function touchPinch (target) {
   function disable () {
     if (!enabled) return
     enabled = false
+    activeCount = 0
+    fingers[0] = null
+    fingers[1] = null
+    lastDistance = 0
+    ended = false
     target.removeEventListener('touchstart', onTouchStart, false)
     target.removeEventListener('touchmove', onTouchMove, false)
     target.removeEventListener('touchend', onTouchRemoved, false)


### PR DESCRIPTION
Similar to Jam3/touches#6, disabling the instance while a touch was in progress would result in state getting out of sync. In this case, it would cause pinches to be triggered on a single touch instead of a double touch.

Thanks! :)