### PR TITLE
Retain event object across artificial events

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ var pinch = require('touch-pinch')
 
 var scale = 1
 pinch(window)
-  .on('change', function (dist, prev) {
-    scale += (dist - prev)
+  .on('change', function (event) {
+    scale += (event.distance - event.lastDistance)
+    event.preventDefault()
   })
 ```
 
@@ -34,20 +35,23 @@ Creates a new `pinch` emitter with the optional `target` element, which defaults
 
 ### events
 
+Events are called with the original event object with additional pinch-specific properties assigned.
+This allows consumers to still do things like `event.preventDefault()`, for example, to prevent mobile window zooming.
+
 #### `pinch.on('start', fn)`
 
 Called when the pinch event begins; i.e. when two fingers are active on screen.
 
-Called with `fn(distance)`, which is the initial Euclidean distance between these two points.
+Called with `fn({distance})`, which is the initial Euclidean distance between these two points.
 
 #### `pinch.on('change', fn)`
 
 Called when the pinch changes; i.e. one or both of the fingers in the pinch have moved.
 
-Called with `fn(distance, prevDistance)`, where `distance` is the new Euclidean distance, and `prevDistance` is the last recorded distance. Often, you will use this delta to compute a new scale:
+Called with `fn({distance, lastDistance})`, where `distance` is the new Euclidean distance, and `lastDistance` is the last recorded distance. Often, you will use this delta to compute a new scale:
 
 ```js
-scale += (distance - prevDistance)
+scale += (distance - lastDistance)
 ```
 
 #### `pinch.on('end', fn)`
@@ -58,13 +62,13 @@ Called when the pinch is finished; i.e. one or both of the active fingers have b
 
 Called before the pinch has started, to indicate that a new finger has been placed on screen (with a maximum of two fingers). 
 
-Called with `fn(newTouch, otherTouch)`, where `newTouch` is the new TouchEvent. `otherTouch` is the touch event that represents the other finger on screen, or `undefined` if none exists.
+Called with `fn({newTouch, otherTouch})`, where `newTouch` is the new TouchEvent. `otherTouch` is the touch event that represents the other finger on screen, or `undefined` if none exists.
 
 #### `pinch.on('lift', fn)`
 
 Called before the pinch has ended, to indicate that a previoulsy pinching finger has been lifted. 
 
-Called with `fn(removedTouch, otherTouch)`, where `removedTouch` is the TouchEvent that was removed from the screen. `otherTouch` is the touch event for the other finger on screen, or `undefined` if none exists.
+Called with `fn({removedTouch, otherTouch})`, where `removedTouch` is the TouchEvent that was removed from the screen. `otherTouch` is the touch event for the other finger on screen, or `undefined` if none exists.
 
 ### members
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var getDistance = require('gl-vec2/distance')
 var EventEmitter = require('events').EventEmitter
 var dprop = require('dprop')
 var eventOffset = require('mouse-event-offset')
+var eventOptions = { capture: false, passive: true };
 
 module.exports = touchPinch
 function touchPinch (target) {
@@ -47,10 +48,10 @@ function touchPinch (target) {
   function enable () {
     if (enabled) return
     enabled = true
-    target.addEventListener('touchstart', onTouchStart, false)
-    target.addEventListener('touchmove', onTouchMove, false)
-    target.addEventListener('touchend', onTouchRemoved, false)
-    target.addEventListener('touchcancel', onTouchRemoved, false)
+    target.addEventListener('touchstart', onTouchStart, eventOptions)
+    target.addEventListener('touchmove', onTouchMove, eventOptions)
+    target.addEventListener('touchend', onTouchRemoved, eventOptions)
+    target.addEventListener('touchcancel', onTouchRemoved, eventOptions)
   }
 
   function disable () {
@@ -61,10 +62,10 @@ function touchPinch (target) {
     fingers[1] = null
     lastDistance = 0
     ended = false
-    target.removeEventListener('touchstart', onTouchStart, false)
-    target.removeEventListener('touchmove', onTouchMove, false)
-    target.removeEventListener('touchend', onTouchRemoved, false)
-    target.removeEventListener('touchcancel', onTouchRemoved, false)
+    target.removeEventListener('touchstart', onTouchStart, eventOptions)
+    target.removeEventListener('touchmove', onTouchMove, eventOptions)
+    target.removeEventListener('touchend', onTouchRemoved, eventOptions)
+    target.removeEventListener('touchcancel', onTouchRemoved, eventOptions)
   }
 
   function onTouchStart (ev) {

--- a/index.js
+++ b/index.js
@@ -33,6 +33,12 @@ function touchPinch (target) {
   emitter.indexOfTouch = indexOfTouch
   return emitter
 
+  function assign(obj, props) {
+    Object.keys(props).forEach(function (prop) {
+      obj[prop] = props[prop]
+    })
+  }
+
   function indexOfTouch (touch) {
     var id = touch.identifier
     for (var i = 0; i < fingers.length; i++) {
@@ -91,13 +97,13 @@ function touchPinch (target) {
         eventOffset(newTouch, target, newFinger.position)
 
         var otherTouch = fingers[oldIndex] ? fingers[oldIndex].touch : undefined
-        Object.assign(ev, {newTouch, otherTouch})
+        assign(ev, {newTouch: newTouch, otherTouch: otherTouch})
         emitter.emit('place', ev)
 
         if (!first) {
           var distance = computeDistance()
           ended = false
-          Object.assign(ev, {distance})
+          assign(ev, {distance: distance})
           emitter.emit('start', ev)
           lastDistance = distance
         }
@@ -119,7 +125,7 @@ function touchPinch (target) {
 
     if (activeCount === 2 && changed) {
       var distance = computeDistance()
-      Object.assign(ev, {distance, lastDistance})
+      assign(ev, {distance: distance, lastDistance: lastDistance})
       emitter.emit('change', ev)
       lastDistance = distance
     }
@@ -135,7 +141,7 @@ function touchPinch (target) {
         activeCount--
         var otherIdx = idx === 0 ? 1 : 0
         var otherTouch = fingers[otherIdx] ? fingers[otherIdx].touch : undefined
-        Object.assign(ev, {removedTouch, otherTouch})
+        assign(ev, {removedTouch: removedTouch, otherTouch: otherTouch})
         emitter.emit('lift', ev)
       }
     }

--- a/index.js
+++ b/index.js
@@ -89,14 +89,16 @@ function touchPinch (target) {
         newFinger.touch = newTouch
         eventOffset(newTouch, target, newFinger.position)
 
-        var oldTouch = fingers[oldIndex] ? fingers[oldIndex].touch : undefined
-        emitter.emit('place', newTouch, oldTouch)
+        var otherTouch = fingers[oldIndex] ? fingers[oldIndex].touch : undefined
+        Object.assign(ev, {newTouch, otherTouch})
+        emitter.emit('place', ev)
 
         if (!first) {
-          var initialDistance = computeDistance()
+          var distance = computeDistance()
           ended = false
-          emitter.emit('start', initialDistance)
-          lastDistance = initialDistance
+          Object.assign(ev, {distance})
+          emitter.emit('start', ev)
+          lastDistance = distance
         }
       }
     }
@@ -115,29 +117,31 @@ function touchPinch (target) {
     }
 
     if (activeCount === 2 && changed) {
-      var currentDistance = computeDistance()
-      emitter.emit('change', currentDistance, lastDistance)
-      lastDistance = currentDistance
+      var distance = computeDistance()
+      Object.assign(ev, {distance, lastDistance})
+      emitter.emit('change', ev)
+      lastDistance = distance
     }
   }
 
   function onTouchRemoved (ev) {
     for (var i = 0; i < ev.changedTouches.length; i++) {
-      var removed = ev.changedTouches[i]
-      var idx = indexOfTouch(removed)
+      var removedTouch = ev.changedTouches[i]
+      var idx = indexOfTouch(removedTouch)
 
       if (idx !== -1) {
         fingers[idx] = null
         activeCount--
         var otherIdx = idx === 0 ? 1 : 0
         var otherTouch = fingers[otherIdx] ? fingers[otherIdx].touch : undefined
-        emitter.emit('lift', removed, otherTouch)
+        Object.assign(ev, {removedTouch, otherTouch})
+        emitter.emit('lift', ev)
       }
     }
 
     if (!ended && activeCount !== 2) {
       ended = true
-      emitter.emit('end')
+      emitter.emit('end', ev)
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-pinch",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "minimal two-finger pinch gesture detection",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
This PR assigns the new events' properties to the original event object, and propagates that.
This allows for constructs such as `event.preventDefault()` (useful in mobile zooming), without having to add it as a parameter to the touch-pinch object.

It also bumps the version to v2.0.2 because it changes the events' contract (i.e. arguments).